### PR TITLE
relatedRecord query operator returns record directly.

### DIFF
--- a/src/cache/observables/has-one-observable.js
+++ b/src/cache/observables/has-one-observable.js
@@ -12,13 +12,6 @@ import 'rxjs/add/observable/empty';
 import '../../rxjs/add/operator/matching';
 import RecordObservable from './record-observable';
 
-function extractRecordFromHasOneResult(value) {
-  if (!value) { return null; }
-
-  const id = Object.keys(value)[0];
-  return value[id];
-}
-
 export default class HasOneObservable extends Observable {
   constructor(subscribe, cache, record, relationship) {
     super(subscribe);
@@ -53,7 +46,7 @@ export default class HasOneObservable extends Observable {
 
   _fetchCurrentRelatedRecord() {
     const result = this.cache.query(qb.relatedRecord(this.record, this.relationship));
-    return extractRecordFromHasOneResult(result);
+    return result;
   }
 
   relatedRecord({ initial = false } = {}) {

--- a/src/cache/query-operators.js
+++ b/src/cache/query-operators.js
@@ -93,7 +93,7 @@ export default {
     if (!data) { return null; }
 
     const [relatedType, relatedRecordId] = data.split(':');
-    return { [relatedRecordId]: cache.get([relatedType, relatedRecordId]) };
+    return cache.get([relatedType, relatedRecordId]);
   },
 
   attribute(context, name) {

--- a/test/tests/unit/cache-test.js
+++ b/test/tests/unit/cache-test.js
@@ -664,8 +664,6 @@ test('#query - relatedRecord', function(assert) {
 
   assert.deepEqual(
     cache.query(oqe('relatedRecord', { type: 'moon', id: 'callisto' }, 'planet')),
-    {
-      jupiter
-    }
+    jupiter
   );
 });


### PR DESCRIPTION
Instead of returning the result wrapped in an object keyed by
`id`, the result is returned directly.
