### PR TITLE
Eliminate lazy model type registration.

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "yuidocjs": "^0.8.1"
   },
   "dependencies": {
-    "orbit-core": "^0.8.0-beta.4",
+    "orbit-core": "^0.8.0-beta.6",
     "rxjs-es": "^5.0.0-beta.11"
   }
 }

--- a/src/cache/query-operators.js
+++ b/src/cache/query-operators.js
@@ -47,10 +47,6 @@ export default {
 
   record(context, { type, id }) {
     const cache = this.target;
-    const schema = cache.schema;
-
-    schema.ensureModelTypeInitialized(type);
-
     const record = cache.get([type, id]);
 
     if (!record) {
@@ -62,10 +58,6 @@ export default {
 
   records(context, type) {
     const cache = this.target;
-    const schema = cache.schema;
-
-    schema.ensureModelTypeInitialized(type);
-
     const records = cache.get([type]);
 
     context.basePath = [type];

--- a/test/tests/unit/cache-test.js
+++ b/test/tests/unit/cache-test.js
@@ -2,8 +2,7 @@ import Schema from 'orbit/schema';
 import KeyMap from 'orbit/key-map';
 import { queryExpression as oqe } from 'orbit/query/expression';
 import {
-  RecordNotFoundException,
-  ModelNotRegisteredException
+  RecordNotFoundException
 } from 'orbit/lib/exceptions';
 import {
   addRecord,
@@ -585,15 +584,6 @@ test('#query - record - throws RecordNotFoundException if record doesn\'t exist'
   );
 });
 
-test('#query - record - throws ModelNotRegisteredException if record type doesn\'t exist', function(assert) {
-  let cache = new Cache({ schema, keyMap });
-
-  assert.throws(
-    () => cache.query(oqe('record', { type: 'black-hole', id: 'jupiter' })),
-    new ModelNotRegisteredException('black-hole')
-  );
-});
-
 test('#query - records - finds matching records', function(assert) {
   let cache = new Cache({ schema, keyMap });
 
@@ -612,15 +602,6 @@ test('#query - records - finds matching records', function(assert) {
   assert.deepEqual(
     cache.query(oqe('records', 'planet')),
     { jupiter }
-  );
-});
-
-test('#query - records - throws ModelNotRegisteredException when model isn\'t registered in schema', function(assert) {
-  let cache = new Cache({ schema, keyMap });
-
-  assert.throws(
-    () => cache.query(oqe('records', 'black-hole')),
-    new ModelNotRegisteredException('black-hole')
   );
 });
 

--- a/test/tests/unit/store-test.js
+++ b/test/tests/unit/store-test.js
@@ -123,7 +123,7 @@ module('OC - Store', function(hooks) {
 
     return store.query(qb.record({ type: 'planet', id: 'jupiter' }))
       .catch(e => {
-        assert.equal(e.message, 'Record not found - planet:jupiter');
+        assert.equal(e.message, 'Record not found: planet:jupiter');
       });
   });
 


### PR DESCRIPTION
Orbit#Schema now only supports eager registration. Schema changes are
supported via explicit version upgrades.
